### PR TITLE
readlink has no -f parameter in macOS

### DIFF
--- a/findom-xss.sh
+++ b/findom-xss.sh
@@ -40,7 +40,11 @@ _help() {
 }
 
 _main() {
-	MAIN="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+	if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+		MAIN="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		MAIN="$(dirname $(stat -f ${BASH_SOURCE[0]}))"
+	fi
 	RESULT="${MAIN}/results"
 	DOMAIN=$(_extractDomain ${1})
 


### PR DESCRIPTION
I added a OS control for fix. It should work both macOS and Linux dist. 

Thanks.